### PR TITLE
fix compilation phase warning

### DIFF
--- a/lmdb.cabal
+++ b/lmdb.cabal
@@ -25,7 +25,7 @@ License: BSD2
 license-file: LICENSE
 Stability: experimental
 build-type: Simple
-cabal-version: >= 1.16.0.3
+cabal-version: 1.16.0.3
 
 Source-repository head
   type: git


### PR DESCRIPTION
## Purpose

Doing what the compilation phase tells me to

lmdb                > Warning: lmdb.cabal:28:27: Packages with 'cabal-version: 1.12' or later should
lmdb                > specify a specific version of the Cabal spec of the form 'cabal-version: x.y'.
lmdb                > Use 'cabal-version: 1.16.0.3'.


## Changes

Fix cabal versioning warning by enforcing specific versioning
